### PR TITLE
Weird versions

### DIFF
--- a/GetVersionsFromGithub.py
+++ b/GetVersionsFromGithub.py
@@ -1,0 +1,33 @@
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+import time
+import random
+from bs4 import BeautifulSoup
+
+
+Headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36'}
+
+BaseURL = "https://github.com/static-dev/axis"
+
+class Cards():
+  def __init__(self, githubURL):
+    self.options = Options()
+    self.options.add_argument("user-agent=%s"%(Headers['User-Agent']))
+    self.options.add_argument('headless')
+    self.driver = webdriver.Chrome(options=self.options)
+    self.URL = githubURL
+
+  def ExtractVersions(self):
+    self.driver.get(self.URL)
+    time.sleep(random.randint(3,6))
+    self.driver.find_element_by_xpath('//button[text()="Branch:"]').click()
+    time.sleep(random.randint(3,6))
+    self.driver.find_element_by_xpath('//button[text()="Tags"]').click()
+    print(self.driver.page_source)
+
+Cards(BaseURL).ExtractVersions()
+    

--- a/VersionComparisonClass.py
+++ b/VersionComparisonClass.py
@@ -83,17 +83,31 @@ class CheckVersion():
         FinalVersion = self.reconstructVersion(VersionNumber, Bracket=Bracket, Prefix=Prefix, Suffix=Suffix)
         return FinalVersion
 
+    def FixLeadingZeros(self, Version):
+        """
+        Some versions are checked as XX.0X.XXX
+        This when referenced with SNYK data only shows XX.X.XXX
+        Example: 1.01.11 can be inferred as 1.11.11 as is the semantic version convention.
+        """
+        NewVersion = []
+        for i in Version:
+            if i[0] == '0' and i[1:]:
+                i = i[1:]
+            NewVersion.append(i)
+        #print("NEW VERSION: ", NewVersion)
+        return '.'.join(NewVersion)
+        
     def reconstructVersion(self, Version, Bracket=None, Prefix=None, Suffix=None):
+        
         VersionList = []
         #Standardizing versions
         if '_' in Version:
             Version = Version.split('_')
-            Version = '.'.join(Version)
         elif "-" in Version:
             Version = Version.split('-')
-            Version = '.'.join(Version)
-
-        #if len(Version.split('.')) > 3:
+        elif "." in Version:
+            Version = Version.split('.')
+        Version = self.FixLeadingZeros(Version)
 
         VersionList.append(Version)
         if Suffix:
@@ -182,8 +196,8 @@ if __name__ == "__main__":
     Test
     """
 
-    VersionRange = ['[,2.6.7.1-jacksondatabind), [2.7,2.7.9.1), [2.8,2.8.10), [2.9.0.pr1,2.9.0)']
-    Versions = CheckVersion(VersionRange, '2.4.6.1-jacksondatabind')
+    VersionRange = ['[,2-67-1-jacksondatabind), [2.7,2.7.9.1), [2.8,2.8.10), [2.9.0.pr1,2.9.0)']
+    Versions = CheckVersion(VersionRange, '2-4-6-1-jacksondatabind')
     print(Versions)
     print(Versions.CheckVersionInRange())
     print("Checking {} in {}".format('3.3-alpha', str(VersionRange)))


### PR DESCRIPTION
Hey, 
The PR provides fixes for version types previously unsupported. 
They fell under two main categories:
- Versions more elaborate than X.X.X(major.minor.patch) such as Y.Y.Y.Y (major.minor.patch.tags). Fix: 
6f7bf75
- Versions with invalid leading zeros ex. 1.01.1 converted to 1.1.1 for fix. Fix: 
01b6de4
Thanks!